### PR TITLE
Makes wlanN interface determined at runtime.

### DIFF
--- a/bin/iface_check.js
+++ b/bin/iface_check.js
@@ -1,8 +1,12 @@
 var 
 	exec = require('child_process').exec
+	, os = require('os')
 	, parser = require(__dirname + '/../lib/iwconfig-parser')
 	, data = {}
 	, opts = { timeout : 100000 }
+	, wlan = Object.keys(os.networkInterfaces()).filter(function(el) {
+		return el.indexOf("wlan") >= 0; 
+		})[0] || "wlan0"
 ;
 
 /**
@@ -51,7 +55,7 @@ function parse(line, index, list) {
 module.exports = function() { 
 
 	data = {};
-	console.log("Checking interface...");
-	exec('iwconfig wlan0', opts, read);
+	console.log("Checking interface "+wlan+"...");
+	exec('iwconfig '+wlan, opts, read);
 
 };

--- a/bin/iface_down.js
+++ b/bin/iface_down.js
@@ -1,18 +1,22 @@
 var 
 	exec = require('child_process').exec
+	, os = require('os')
 	, opts = { timeout : 100000 }
+        , wlan = Object.keys(os.networkInterfaces()).filter(function(el) {
+                return el.indexOf("wlan") >= 0;
+                })[0] || "wlan0"
 ;
 
 var error = function(err) {
 
-	console.log("Error taking interface wlan0 down.", err);
+	console.log("Error taking interface "+wlan+" down.", err);
 	process.send({ 'action' : 'ifaceDown', 'error' : err });
 };
 
 var down = function() { 
 	
-	console.log("Taking interface wlan0 down...")
-	exec('sudo ifconfig wlan0 down', opts, done);
+	console.log("Taking interface "+wlan+" down...")
+	exec('sudo ifconfig '+wlan+' down', opts, done);
 };
 
 var done = function(err, stdout, stderr) {
@@ -22,7 +26,7 @@ var done = function(err, stdout, stderr) {
 		return error(err); 
 	}
 
-	console.log("Interface wlan0 down.");
+	console.log("Interface "+wlan+" down.");
 	process.send({ 'action' : 'ifaceDown', 'data' : true });
 };
 

--- a/bin/iface_up.js
+++ b/bin/iface_up.js
@@ -1,18 +1,22 @@
 var 
 	exec = require('child_process').exec
+	, os = require('os')
 	, opts = { timeout : 100000 }
+        , wlan = Object.keys(os.networkInterfaces()).filter(function(el) {
+                return el.indexOf("wlan") >= 0;
+                })[0] || "wlan0"
 ;
 
 var error = function(err) {
 	
-	console.log("Error bringing interface wlan0 up.", err);
+	console.log("Error bringing interface "+wlan+" up.", err);
 	process.send({ 'action' : 'ifaceUp', 'error' : err });
 };
 
 var up = function() { 
 	
-	console.log("Bringing interface wlan0 up...");
-	exec('sudo ifconfig wlan0 up', opts, done);
+	console.log("Bringing interface "+wlan+" up...");
+	exec('sudo ifconfig '+wlan+' up', opts, done);
 };
 
 var done = function(err, stdout, stderr) {
@@ -22,7 +26,7 @@ var done = function(err, stdout, stderr) {
 		return error(err); 
 	}
 
-	console.log("Interface wlan0 up.");
+	console.log("Interface "+wlan+" up.");
 	process.send({ 'action' : 'ifaceUp', 'data' : true });
 };
 


### PR DESCRIPTION
The `/etc/udev/rules.d/` rules can have the consequence that new wireless adapters get wlanN interfaces assigned with N > 0. For me, this was the case factory-wise, probably because the block had been tested factory-side with a wireless adapter different from the one that shipped with it.
